### PR TITLE
fix: sync pnpm-lock.yaml specifiers with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(terser@5.46.2)
       zod:
-        specifier: '4'
+        specifier: ^4.0.0
         version: 4.4.3
 
   packages/utils:
@@ -52,7 +52,7 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(terser@5.46.2)
       zod:
-        specifier: '4'
+        specifier: ^4.0.0
         version: 4.4.3
 
 packages:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CI release workflow fails with:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with packages/utils/package.json

specifiers in the lockfile ({"zod":"4"}) don't match specs in package.json ({"zod":"^4.0.0"})
```

## Root Cause

When zod v4 was installed via `pnpm add -D zod@4`, pnpm wrote the bare specifier `"4"` into the lockfile. The package.json was then manually updated to `"^4.0.0"` for proper semver range support, but `pnpm install` was not re-run to sync the lockfile specifier.

## Fix

Ran `pnpm install` to regenerate the lockfile with matching specifiers (`^4.0.0` in both places). This is a 2-line diff — only the `specifier:` fields change, resolved versions are identical.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

