### PR TITLE
chore: release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adaptate",
-  "version": "1.0.0+beta.sha.6a96a7d",
+  "version": "2.0.0",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adaptate/core",
-  "version": "1.0.0+beta.sha.6a96a7d",
+  "version": "2.0.0",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adaptate/utils",
-  "version": "1.0.0+beta.sha.6a96a7d",
+  "version": "2.0.0",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release v2.0.0 + Auto-bump release workflow

### Version bump

Bumps all packages from `1.0.0+beta.sha.6a96a7d` → `2.0.0`.

### New release workflow

Replaces the old path-trigger workflow with a manual `workflow_dispatch` flow:

**How to release (after merging this):**

1. Go to Actions → "Release" → "Run workflow"
2. Select bump type: `patch`, `minor`, or `major`
3. The workflow automatically:
   - Computes the next version from current `package.json`
   - Updates all 3 package.json files (root + core + utils)
   - Builds the project (`turbo run build`)
   - Publishes to npm (`pnpm publish --recursive --provenance --access public`)
   - Commits the version bump and creates a git tag (`v2.0.1`, etc.)

**Why this is better than the old flow:**

| Old | New |
|-----|-----|
| Triggered on any `package.json` path change | Triggered manually with explicit intent |
| Required manual version bump before merge | Auto-bumps as part of the release |
| No git tag created | Creates `vX.Y.Z` tag automatically |
| Used `pnpm@latest` (unpinned) | Uses `pnpm@9.12.3` (pinned to match repo) |
| No `--frozen-lockfile` | Uses `--frozen-lockfile` for reproducibility |

---

### Breaking changes (since 1.0.0)

- **Minimum zod peer dependency**: `^3.25.0 || ^4.0.0` (was `^3.23.8`)
- Zod v4 error message format changed

### Packages published

| Package | Version |
|---------|---------|
| `adaptate` | 2.0.0 |
| `@adaptate/core` | 2.0.0 |
| `@adaptate/utils` | 2.0.0 |

**Note:** After merging, manually trigger the "Release" workflow to publish. Since the new workflow is dispatch-only, merging alone won't publish. The first release (v2.0.0) is already set in the version fields — just run the workflow without bumping, or run with `patch` to publish as v2.0.1.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

