### PR TITLE
ci: add auto-trigger on version change alongside manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,14 @@
 name: Release
 
 on:
+  # Auto-trigger: version change in package.json on main
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+
+  # Manual trigger: bump and publish
   workflow_dispatch:
     inputs:
       bump:
@@ -25,25 +33,44 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 2
+
+      - name: Check version changed (auto-trigger)
+        id: check
+        if: github.event_name == 'push'
+        run: |
+          CURRENT=$(node -e "console.log(require('./package.json').version)")
+          PREVIOUS=$(git show HEAD~1:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
+          if [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "publish=true" >> $GITHUB_OUTPUT
+            echo "Version changed: $PREVIOUS → $CURRENT"
+          else
+            echo "publish=false" >> $GITHUB_OUTPUT
+            echo "Version unchanged, skipping"
+          fi
 
       - name: Set up Node.js
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
         run: |
           corepack enable
           corepack prepare pnpm@latest --activate
           pnpm install --frozen-lockfile
 
       - name: Configure git
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
+      - name: Bump version (manual only)
+        if: github.event_name == 'workflow_dispatch'
         run: |
           NEW_VERSION=$(node -e "
             const pkg = require('./package.json');
@@ -67,15 +94,29 @@ jobs:
             }
           "
 
+      - name: Read version (auto-trigger)
+        if: github.event_name == 'push' && steps.check.outputs.publish == 'true'
+        run: |
+          echo "NEW_VERSION=$(node -e "console.log(require('./package.json').version)")" >> $GITHUB_ENV
+
       - name: Build
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
         run: npx turbo run build
 
       - name: Publish to npm
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
         run: pnpm publish --recursive --provenance --access public --no-git-checks
 
-      - name: Commit and tag
+      - name: Commit and tag (manual only)
+        if: github.event_name == 'workflow_dispatch'
         run: |
           git add package.json packages/*/package.json
           git commit -m "chore: release v${NEW_VERSION}"
           git tag "v${NEW_VERSION}"
           git push origin main --tags
+
+      - name: Tag (auto-trigger)
+        if: github.event_name == 'push' && steps.check.outputs.publish == 'true'
+        run: |
+          git tag "v${NEW_VERSION}"
+          git push origin --tags


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Add auto-trigger to release workflow

Both modes now work:

| Trigger | How | What happens |
|---------|-----|-------------|
| **Auto** | Bump version in PR → merge to main | Detects version change → builds → publishes → tags |
| **Manual** | Actions → Release → Run workflow | Pick bump type → auto-bumps → builds → publishes → commits → tags |

### Auto-trigger safety

Compares `package.json` version at `HEAD~1` vs `HEAD`. Only publishes when the version actually changed — won't fire on other package.json edits (like adding a script or keyword).

### To publish v2.0.0 now

After merging this PR, either:
- **Manual:** Run workflow with `patch` (publishes as 2.0.1)
- **Auto:** Push a commit to main that changes the version in `package.json`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

