### PR TITLE
fix: remove registry-url blocking OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fix

The `registry-url` line was still in main (my earlier fix didn't make it into the merged commit). This one-line removal is the fix:

```diff
- registry-url: 'https://registry.npmjs.org/'
```

`setup-node` with `registry-url` creates `~/.npmrc` with `NODE_AUTH_TOKEN=${{ secrets.NPM_USER_TOKEN }}`. Even with the secret deleted, it injects an empty/invalid token that overrides OIDC.

After merge, run the workflow again.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-432dc226-11c0-4a05-a518-fd8dbcb63f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

