### PR TITLE
ci(🛡️): harden release workflow with reusable publish, OIDC isolation, and required reviewers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: '24'
+          node-version: "24"
+          package-manager-cache: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           package-manager-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,58 +17,80 @@ on:
           - rc
           - beta
           - alpha
-          - as-is # ← New option for rare cases
+          - as-is
+
+permissions:
+  contents: read
 
 jobs:
-  release:
+  # =====================
+  # JOB 1: Build + Verify (Read-only)
+  # =====================
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.1 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: npx turbo run build
+
+      - name: Test
+        run: pnpm test
 
       - name: Check version changed (auto-trigger)
         id: check
         if: github.event_name == 'push'
         run: |
           CURRENT=$(node -e "console.log(require('./package.json').version)")
-          PREVIOUS=$(git show HEAD\~1:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
+          PREVIOUS=$(git show HEAD~1:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
           echo "publish=$([ "$CURRENT" != "$PREVIOUS" ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
-      - name: Setup Node.js
-        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
+  # =====================
+  # JOB 2: Publish (calls reusable workflow)
+  # =====================
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && needs.build.outputs.publish == 'true')
 
-      - name: Install dependencies
-        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
-        run: |
-          corepack enable
-          corepack prepare pnpm@11.1.1  --activate
-          pnpm install --frozen-lockfile --ignore-scripts
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'release' || '' }}
 
-      - name: Configure git
-        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      # === Version Bump (skipped when "as-is" is selected) ===
-      - name: Bump version (manual only)
+      # Version bump logic (manual only)
+      - name: Bump version (manual)
         if: github.event_name == 'workflow_dispatch' && inputs.bump != 'as-is'
         run: |
           NEW_VERSION=$(node -e "
             const pkg = require('./package.json');
             let version = pkg.version;
             const bump = '${{ inputs.bump }}';
-            
+
             if (['rc', 'beta', 'alpha'].includes(bump)) {
               const base = version.replace(/-[a-zA-Z0-9.]+$/, '');
               console.log(base + '-' + bump + '.1');
@@ -81,7 +103,6 @@ jobs:
             }
           ")
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          echo "Bumping to $NEW_VERSION"
 
           node -e "
             const fs = require('fs');
@@ -94,44 +115,31 @@ jobs:
             }
           "
 
-      - name: Read version (auto-trigger or as-is)
-        if: (github.event_name == 'push' && steps.check.outputs.publish == 'true') || (github.event_name == 'workflow_dispatch' && inputs.bump == 'as-is')
+      - name: Read current version
+        if: (github.event_name == 'push' && needs.build.outputs.publish == 'true') || (github.event_name == 'workflow_dispatch' && inputs.bump == 'as-is')
         run: echo "NEW_VERSION=$(node -e "console.log(require('./package.json').version)")" >> $GITHUB_ENV
 
-      - name: Lint
-        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
-        run: pnpm lint
+      - name: Call Publish Reusable Workflow
+        uses: ./.github/workflows/reusable-publish.yml
+        with:
+          version: ${{ env.NEW_VERSION }}
+          is_manual: ${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Build
-        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
-        run: npx turbo run build
-
-      # === Publish All Packages ===
-      - name: Publish to npm (OIDC + Provenance)
-        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.publish == 'true'
-        run: |
-          echo "=== Publishing workspace packages ==="
-          for dir in packages/core packages/utils; do
-            if [ -f "$dir/package.json" ]; then
-              echo ">>> Publishing: $dir"
-              (cd "$dir" && npx npm@latest publish --provenance --access public)
-            fi
-          done
-
-          echo ""
-          echo "=== Publishing root package (adaptate) ==="
-          npx npm@latest publish --provenance --access public
-
-      - name: Commit and tag (manual only, skip if as-is)
+      # Git operations (only on manual bump)
+      - name: Commit and push (manual bump)
         if: github.event_name == 'workflow_dispatch' && inputs.bump != 'as-is'
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json packages/*/package.json
           git commit -m "chore: release v${NEW_VERSION}"
           git tag "v${NEW_VERSION}"
           git push origin main --tags
 
-      - name: Tag (auto-trigger or as-is)
-        if: (github.event_name == 'push' && steps.check.outputs.publish == 'true') || (github.event_name == 'workflow_dispatch' && inputs.bump == 'as-is')
+      - name: Create tag (auto or as-is)
+        if: (github.event_name == 'push' && needs.build.outputs.publish == 'true') || (github.event_name == 'workflow_dispatch' && inputs.bump == 'as-is')
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v${NEW_VERSION}"
           git push origin --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           package-manager-cache: false
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # Version bump logic (manual only)
       - name: Bump version (manual)

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           package-manager-cache: false

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -1,17 +1,24 @@
-name: Verify npm OIDC Connection (Dry Run)
+name: Reusable - Publish Packages (OIDC + Provenance)
 
 on:
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      is_manual:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  verify-oidc:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
+    environment: ${{ inputs.is_manual && 'release' || '' }}
 
     steps:
       - name: Checkout
@@ -32,18 +39,15 @@ jobs:
       - name: Build
         run: npx turbo run build
 
-      - name: Dry-run publish (OIDC + provenance)
+      - name: Publish workspace packages
         run: |
-          echo "=== Testing OIDC + Provenance ==="
-
+          echo "=== Publishing workspace packages ==="
           for dir in packages/core packages/utils; do
             if [ -f "$dir/package.json" ]; then
-              echo ""
-              echo ">>> Testing package: $dir"
-              (cd "$dir" && npx npm@latest publish --dry-run --provenance --access public)
+              echo ">>> Publishing: $dir"
+              (cd "$dir" && npx npm@latest publish --provenance --access public)
             fi
           done
 
-      - name: ✅ OIDC Connection Verified Successfully
-        if: success()
-        run: echo "✅ GitHub ↔ npmjs OIDC connection is working!"
+      - name: Publish root package (adaptate)
+        run: npx npm@latest publish --provenance --access public

--- a/.github/workflows/verify-npm-oidc.yml
+++ b/.github/workflows/verify-npm-oidc.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           package-manager-cache: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adaptate",
-  "version": "2.2.1",
+  "version": "2.2.2-beta",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"


### PR DESCRIPTION
## Summary

This PR significantly hardens the release and publishing workflow following recent supply chain attack patterns (e.g. TanStack incident).

### Key Improvements

- **Split into two jobs**: `build` (read-only) and `publish` for better separation of concerns.
- **Introduced reusable workflow** (`.github/workflows/reusable-publish.yml`) for the actual publishing logic with `id-token: write`.
- **Added GitHub Environment** (`release`) with **Required reviewers** for manual publishes via `workflow_dispatch`.
- **Pinned all actions** to full commit SHAs.
- **Disabled package manager cache** in release-related workflows to reduce cache poisoning risk.
- **Reduced permissions** and followed least-privilege principles.
- Minor hardening applied to `ci.yml` and `verify-npm-oidc.yml`.

### Files Changed

- `.github/workflows/reusable-publish.yml` (new)
- `.github/workflows/release.yml` (major refactor)
- `.github/workflows/ci.yml` (improved)
- `.github/workflows/verify-npm-oidc.yml` (improved)

### Security Benefits

- Manual publishes now require explicit approval.
- Publishing permissions (`id-token: write`) are isolated in a reusable workflow.
- Build and test steps run with read-only permissions.
- Reduced attack surface for supply chain attacks via GitHub Actions.

### Required GitHub UI Configuration

Before merging, please ensure the following is configured:

- [x] Created `release` Environment with **Required reviewers** enabled
- [x] Deployment branches set to `main`
- [x] (Recommended) Protected `main` branch
