### PR TITLE
refactor(ci): simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,126 +2,59 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-          - rc
-          - beta
-          - alpha
-          - as-is
 
 permissions:
   contents: read
 
 jobs:
-  prepare-release:
+  check-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      current_version: ${{ steps.version.outputs.current_version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "24"
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Calculate new version
+      - name: Get current version
         id: version
         run: |
-          if [ "${{ inputs.bump }}" = "as-is" ]; then
-            VERSION=$(node -e "console.log(require('./package.json').version)")
-          else
-            VERSION=$(node -e '
-              const pkg = require("./package.json");
-              let version = pkg.version;
-              const bump = "${{ inputs.bump }}";
+          CURRENT=$(node -e "console.log(require('./package.json').version)")
+          echo "current_version=$CURRENT" >> $GITHUB_OUTPUT
 
-              if (["rc", "beta", "alpha"].includes(bump)) {
-                const base = version.replace(/-[a-zA-Z0-9.]+$/, "");
-                console.log(base + "-" + bump + ".1");
-              } else {
-                const clean = version.replace(/[+-].*$/, "");
-                const [major, minor, patch] = clean.split(".").map(Number);
-                if (bump === "major") console.log((major + 1) + ".0.0");
-                else if (bump === "minor") console.log(major + "." + (minor + 1) + ".0");
-                else console.log(major + "." + minor + "." + (patch + 1));
-              }
-            ')
+      - name: Check if version changed since last tag
+        id: check
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous tags found. Allowing publish."
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            exit 0
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - name: Create release branch
-        if: inputs.bump != 'as-is'
-        run: |
-          BRANCH_NAME="release/v${VERSION}"
-          git checkout -b "$BRANCH_NAME"
+          TAG_VERSION=$(git show $LATEST_TAG:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
+          CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
 
-      - name: Update package versions
-        if: inputs.bump != 'as-is'
-        run: |
-          node -e '
-            const fs = require("fs");
-            const version = "${{ env.VERSION }}";
-            const files = ["package.json", "packages/core/package.json", "packages/utils/package.json"];
-            files.forEach(file => {
-              if (fs.existsSync(file)) {
-                const pkg = JSON.parse(fs.readFileSync(file));
-                pkg.version = version;
-                fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
-              }
-            });
-          '
-
-      - name: Commit, tag and push
-        if: inputs.bump != 'as-is'
-        run: |
-          VERSION="${{ env.VERSION }}"
-          git add package.json packages/*/package.json
-          git commit -m "chore(release): v${VERSION}"
-          git tag "v${VERSION}"
-          git push origin "release/v${VERSION}" --tags
-
-      - name: Create tag (as-is)
-        if: inputs.bump == 'as-is'
-        run: |
-          VERSION=$(node -e "console.log(require('./package.json').version)")
-          git tag "v${VERSION}"
-          git push origin --tags
-
-      - name: Set version output
-        id: version
-        run: |
-          FINAL_VERSION="${{ env.VERSION || $(node -e "console.log(require('./package.json').version)") }}"
-          echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
+          if [ "$CURRENT_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version changed ($TAG_VERSION → $CURRENT_VERSION). Allowing publish."
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version has not changed since last tag ($TAG_VERSION). Skipping publish."
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          fi
 
   publish:
-    needs: prepare-release
+    needs: check-version
+    if: needs.check-version.outputs.should_publish == 'true'
     permissions:
       contents: read
       id-token: write
 
     uses: ./.github/workflows/reusable-publish.yml
     with:
-      version: ${{ needs.prepare-release.outputs.version }}
+      version: ${{ needs.check-version.outputs.current_version }}
       is_manual: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,10 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
-    paths: ["package.json"]
   workflow_dispatch:
     inputs:
       bump:
-        description: "Version bump type (or as-is for no change)"
+        description: "Version bump type"
         required: true
         type: choice
         options:
@@ -23,114 +20,108 @@ permissions:
   contents: read
 
 jobs:
-  # =====================
-  # JOB 1: Build + Version Preparation
-  # =====================
-  build:
+  prepare-release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     outputs:
-      version: ${{ steps.set-version.outputs.version }}
-      should_publish: ${{ steps.check-publish.outputs.publish || 'true' }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
-          package-manager-cache: false
 
-      - name: Install dependencies
+      - name: Configure Git
         run: |
-          corepack enable
-          corepack prepare pnpm@11.1.1 --activate
-          pnpm install --frozen-lockfile --ignore-scripts
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Lint
-        run: pnpm lint
-
-      - name: Build
-        run: npx turbo run build
-
-      - name: Test
-        run: pnpm test
-
-      # Check if version changed (for auto publish on push)
-      - name: Check if should publish (auto)
-        id: check-publish
-        if: github.event_name == 'push'
+      - name: Calculate new version
+        id: version
         run: |
-          CURRENT=$(node -e "console.log(require('./package.json').version)")
-          PREVIOUS=$(git show HEAD~1:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
-          echo "publish=$([ "$CURRENT" != "$PREVIOUS" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.bump }}" = "as-is" ]; then
+            VERSION=$(node -e "console.log(require('./package.json').version)")
+          else
+            VERSION=$(node -e '
+              const pkg = require("./package.json");
+              let version = pkg.version;
+              const bump = "${{ inputs.bump }}";
 
-      # Version bumping (only on manual workflow_dispatch)
-      - name: Bump version (manual)
-        if: github.event_name == 'workflow_dispatch' && inputs.bump != 'as-is'
+              if (["rc", "beta", "alpha"].includes(bump)) {
+                const base = version.replace(/-[a-zA-Z0-9.]+$/, "");
+                console.log(base + "-" + bump + ".1");
+              } else {
+                const clean = version.replace(/[+-].*$/, "");
+                const [major, minor, patch] = clean.split(".").map(Number);
+                if (bump === "major") console.log((major + 1) + ".0.0");
+                else if (bump === "minor") console.log(major + "." + (minor + 1) + ".0");
+                else console.log(major + "." + minor + "." + (patch + 1));
+              }
+            ')
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create release branch
+        if: inputs.bump != 'as-is'
         run: |
-          NEW_VERSION=$(node -e '
-            const pkg = require("./package.json");
-            let version = pkg.version;
-            const bump = "${{ inputs.bump }}";
+          BRANCH_NAME="release/v${VERSION}"
+          git checkout -b "$BRANCH_NAME"
 
-            if (["rc", "beta", "alpha"].includes(bump)) {
-              const base = version.replace(/-[a-zA-Z0-9.]+$/, "");
-              console.log(base + "-" + bump + ".1");
-            } else {
-              const clean = version.replace(/[+-].*$/, "");
-              const [major, minor, patch] = clean.split(".").map(Number);
-              if (bump === "major") console.log((major + 1) + ".0.0");
-              else if (bump === "minor") console.log(major + "." + (minor + 1) + ".0");
-              else console.log(major + "." + minor + "." + (patch + 1));
-            }
-          ')
-
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-
-          # Update all package.json files
+      - name: Update package versions
+        if: inputs.bump != 'as-is'
+        run: |
           node -e '
             const fs = require("fs");
-            const version = process.env.NEW_VERSION;
+            const version = "${{ env.VERSION }}";
             const files = ["package.json", "packages/core/package.json", "packages/utils/package.json"];
-            for (const file of files) {
+            files.forEach(file => {
               if (fs.existsSync(file)) {
-                const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+                const pkg = JSON.parse(fs.readFileSync(file));
                 pkg.version = version;
                 fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
               }
-            }
+            });
           '
 
-      # Set final version as output
-      - name: Set version output
-        id: set-version
+      - name: Commit, tag and push
+        if: inputs.bump != 'as-is'
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.bump }}" != "as-is" ]; then
-            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "version=$(node -e "console.log(require('./package.json').version)")" >> $GITHUB_OUTPUT
-          fi
+          VERSION="${{ env.VERSION }}"
+          git add package.json packages/*/package.json
+          git commit -m "chore(release): v${VERSION}"
+          git tag "v${VERSION}"
+          git push origin "release/v${VERSION}" --tags
 
-  # =====================
-  # JOB 2: Publish (Reusable Workflow at JOB level)
-  # =====================
+      - name: Create tag (as-is)
+        if: inputs.bump == 'as-is'
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          git tag "v${VERSION}"
+          git push origin --tags
+
+      - name: Set version output
+        id: version
+        run: |
+          FINAL_VERSION="${{ env.VERSION || $(node -e "console.log(require('./package.json').version)") }}"
+          echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
+
   publish:
-    needs: build
-    if: needs.build.outputs.should_publish == 'true'
-
-    # ✅ Required when calling a reusable workflow that needs id-token
+    needs: prepare-release
     permissions:
       contents: read
       id-token: write
 
     uses: ./.github/workflows/reusable-publish.yml
     with:
-      version: ${{ needs.build.outputs.version }}
-      is_manual: ${{ github.event_name == 'workflow_dispatch' }}
+      version: ${{ needs.prepare-release.outputs.version }}
+      is_manual: true

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -6,10 +6,12 @@ on:
       version:
         required: true
         type: string
+        description: "Current version being published (for logging)"
       is_manual:
         required: false
         type: boolean
         default: false
+        description: "Whether triggered manually"
 
 permissions:
   contents: read
@@ -41,7 +43,7 @@ jobs:
 
       - name: Publish workspace packages
         run: |
-          echo "=== Publishing workspace packages ==="
+          echo "=== Publishing workspace packages (version: ${{ inputs.version }}) ==="
           for dir in packages/core packages/utils; do
             if [ -f "$dir/package.json" ]; then
               echo ">>> Publishing: $dir"
@@ -49,5 +51,7 @@ jobs:
             fi
           done
 
-      - name: Publish root package (adaptate)
-        run: npx npm@latest publish --provenance --access public
+      - name: Publish root package
+        run: |
+          echo "=== Publishing root package (version: ${{ inputs.version }}) ==="
+          npx npm@latest publish --provenance --access public

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Build
         run: npx turbo run build
 
+      - name: Publish root package
+        run: |
+          echo "=== Publishing root package (version: ${{ inputs.version }}) ==="
+          npx npm@latest publish --provenance --access public
+
       - name: Publish workspace packages
         run: |
           echo "=== Publishing workspace packages (version: ${{ inputs.version }}) ==="
@@ -50,8 +55,3 @@ jobs:
               (cd "$dir" && npx npm@latest publish --provenance --access public)
             fi
           done
-
-      - name: Publish root package
-        run: |
-          echo "=== Publishing root package (version: ${{ inputs.version }}) ==="
-          npx npm@latest publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adaptate",
-  "version": "2.2.2",
+  "version": "2.2.3-beta.0",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adaptate/core",
-  "version": "2.2.2",
+  "version": "2.2.3-beta.0",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adaptate/utils",
-  "version": "2.2.2",
+  "version": "2.2.3-beta.0",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"


### PR DESCRIPTION
## Summary

After going through multiple iterations of hardening and over-engineering the release workflow (release branches, version selection in UI, alpha/beta/rc options, etc.), we've decided to simplify it significantly.

### What Changed

- Removed auto `push` trigger for publishing
- Removed complex version bump selection (patch/minor/major/rc/beta/alpha) from the UI
- Version bump must now come through a normal PR (reviewed)
- Workflow now simply checks: *"Has the version in `main` changed since the last tag?"*
- If yes → Publish
- If no → Skip (prevents accidental re-publishing)

### Why We Simplified

The previous versions became too complicated for our actual needs. We wanted security and control, but ended up with too much magic. This version is cleaner, easier to understand, and still secure.

### Benefits

- Much simpler to maintain
- Version changes go through normal PR review process
- Still protected by the `release` environment + required reviewers
- Less chance of workflow bugs

---

**Note:** This is the final simplified version after multiple rounds of hardening and cleanup.