### PR TITLE
fix(ci): auto detect and set correct dist-tag for prerelease versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Only manual trigger for safety (after Mini Shai-Hulud lessons)
 
 permissions:
   contents: read
@@ -9,6 +9,7 @@ permissions:
 jobs:
   check-version:
     runs-on: ubuntu-latest
+
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       current_version: ${{ steps.version.outputs.current_version }}
@@ -19,28 +20,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get current version
+      - name: Get current version from package.json
         id: version
         run: |
           CURRENT=$(node -e "console.log(require('./package.json').version)")
           echo "current_version=$CURRENT" >> $GITHUB_OUTPUT
 
-      - name: Check if version changed since last tag
+      - name: Check if version changed since last release tag
         id: check
         run: |
+          # Get the latest tag. If no tags exist, allow publishing.
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           if [ -z "$LATEST_TAG" ]; then
-            echo "No previous tags found. Allowing publish."
+            echo "No previous tags found. Allowing first publish."
             echo "should_publish=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
+          # Get version from the last tag
           TAG_VERSION=$(git show $LATEST_TAG:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
           CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
 
           if [ "$CURRENT_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version changed ($TAG_VERSION → $CURRENT_VERSION). Allowing publish."
+            echo "Version changed from $TAG_VERSION to $CURRENT_VERSION. Publishing allowed."
             echo "should_publish=true" >> $GITHUB_OUTPUT
           else
             echo "Version has not changed since last tag ($TAG_VERSION). Skipping publish."
@@ -50,9 +53,10 @@ jobs:
   publish:
     needs: check-version
     if: needs.check-version.outputs.should_publish == 'true'
+
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for OIDC trusted publishing
 
     uses: ./.github/workflows/reusable-publish.yml
     with:

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -6,12 +6,12 @@ on:
       version:
         required: true
         type: string
-        description: "Current version being published (for logging)"
+        description: "Version being published (used for logging)"
       is_manual:
         required: false
         type: boolean
         default: false
-        description: "Whether triggered manually"
+        description: "Whether this was triggered manually (affects environment protection)"
 
 permissions:
   contents: read
@@ -20,7 +20,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.is_manual && 'release' || '' }}
+    environment: ${{ inputs.is_manual && 'release' || '' }} # Requires approval for manual publishes
 
     steps:
       - name: Checkout
@@ -41,17 +41,36 @@ jobs:
       - name: Build
         run: npx turbo run build
 
-      - name: Publish root package
+      - name: Determine dist-tag for publishing
+        id: tag
         run: |
-          echo "=== Publishing root package (version: ${{ inputs.version }}) ==="
-          npx npm@latest publish --provenance --access public
+          VERSION="${{ inputs.version }}"
+
+          # Prerelease versions (rc, beta, alpha) cannot be published to 'latest' tag
+          if [[ "$VERSION" == *"-rc."* ]]; then
+            echo "tag=rc"
+          elif [[ "$VERSION" == *"-beta."* ]]; then
+            echo "tag=beta"
+          elif [[ "$VERSION" == *"-alpha."* ]]; then
+            echo "tag=alpha"
+          else
+            echo "tag=latest"
+          fi >> $GITHUB_OUTPUT
 
       - name: Publish workspace packages
         run: |
-          echo "=== Publishing workspace packages (version: ${{ inputs.version }}) ==="
+          TAG="${{ steps.tag.outputs.tag }}"
+          echo "=== Publishing workspace packages with tag: $TAG ==="
+
           for dir in packages/core packages/utils; do
             if [ -f "$dir/package.json" ]; then
               echo ">>> Publishing: $dir"
-              (cd "$dir" && npx npm@latest publish --provenance --access public)
+              (cd "$dir" && npx npm@latest publish --tag "$TAG" --provenance --access public)
             fi
           done
+
+      - name: Publish root package
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          echo "=== Publishing root package with tag: $TAG ==="
+          npx npm@latest publish --tag "$TAG" --provenance --access public


### PR DESCRIPTION
## Summary

Fixes an error that occurred when trying to publish prerelease versions (e.g. `2.2.2-rc.1`, `2.2.2-beta.3`):

> `npm error You must specify a tag using --tag when publishing a prerelease version.`

### Changes Made

- Updated `reusable-publish.yml` to automatically detect prerelease versions.
- The workflow now sets the appropriate dist-tag before publishing:
  - Versions containing `-rc.` → `--tag rc`
  - Versions containing `-beta.` → `--tag beta`
  - Versions containing `-alpha.` → `--tag alpha`
  - Normal versions → `--tag latest`
- Added comments explaining the logic.

### Why

npm does not allow publishing prerelease versions to the default `latest` tag. This change makes the publish step handle both stable and prerelease versions correctly without manual intervention.