### PR TITLE
feat(ci): publish first, then automatically create tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,62 @@
 name: Release
 
 on:
-  workflow_dispatch: # Only manual trigger for safety (after Mini Shai-Hulud lessons)
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  check-version:
+  release:
     runs-on: ubuntu-latest
-
-    outputs:
-      should_publish: ${{ steps.check.outputs.should_publish }}
-      current_version: ${{ steps.version.outputs.current_version }}
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get current version from package.json
+      - name: Get current version
         id: version
         run: |
           CURRENT=$(node -e "console.log(require('./package.json').version)")
           echo "current_version=$CURRENT" >> $GITHUB_OUTPUT
 
-      - name: Check if version changed since last release tag
+      - name: Check if version changed since last tag
         id: check
         run: |
-          # Get the latest tag. If no tags exist, allow publishing.
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           if [ -z "$LATEST_TAG" ]; then
-            echo "No previous tags found. Allowing first publish."
             echo "should_publish=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Get version from the last tag
           TAG_VERSION=$(git show $LATEST_TAG:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
           CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
 
           if [ "$CURRENT_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version changed from $TAG_VERSION to $CURRENT_VERSION. Publishing allowed."
             echo "should_publish=true" >> $GITHUB_OUTPUT
           else
-            echo "Version has not changed since last tag ($TAG_VERSION). Skipping publish."
             echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 
-  publish:
-    needs: check-version
-    if: needs.check-version.outputs.should_publish == 'true'
+      - name: Publish
+        if: steps.check.outputs.should_publish == 'true'
+        uses: ./.github/workflows/reusable-publish.yml
+        with:
+          version: ${{ steps.version.outputs.current_version }}
+          is_manual: true
 
-    permissions:
-      contents: read
-      id-token: write # Required for OIDC trusted publishing
-
-    uses: ./.github/workflows/reusable-publish.yml
-    with:
-      version: ${{ needs.check-version.outputs.current_version }}
-      is_manual: true
+      - name: Create and push annotated tag (after successful publish)
+        if: steps.check.outputs.should_publish == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.current_version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,18 @@
 name: Release
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Only manual trigger for safety (after Mini Shai-Hulud lessons)
 
 permissions:
   contents: read
 
 jobs:
-  release:
+  check-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
+
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      current_version: ${{ steps.version.outputs.current_version }}
 
     steps:
       - name: Checkout
@@ -19,34 +20,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get current version
+      - name: Get current version from package.json
         id: version
         run: |
           CURRENT=$(node -e "console.log(require('./package.json').version)")
           echo "current_version=$CURRENT" >> $GITHUB_OUTPUT
 
-      - name: Check if version changed since last tag
+      - name: Check if version changed since last release tag
         id: check
         run: |
+          # Get the latest tag. If no tags exist, allow publishing.
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           if [ -z "$LATEST_TAG" ]; then
+            echo "No previous tags found. Allowing first publish."
             echo "should_publish=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
+          # Get version from the last tag
           TAG_VERSION=$(git show $LATEST_TAG:package.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
           CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
 
           if [ "$CURRENT_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version changed from $TAG_VERSION to $CURRENT_VERSION. Publishing allowed."
             echo "should_publish=true" >> $GITHUB_OUTPUT
           else
+            echo "Version has not changed since last tag ($TAG_VERSION). Skipping publish."
             echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish & Create Tag
-        if: steps.check.outputs.should_publish == 'true'
-        uses: ./.github/workflows/reusable-publish.yml
-        with:
-          version: ${{ steps.version.outputs.current_version }}
-          is_manual: true
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.should_publish == 'true'
+
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC trusted publishing (npm provenance)
+
+    uses: ./.github/workflows/reusable-publish.yml
+    with:
+      version: ${{ needs.check-version.outputs.current_version }}
+      is_manual: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       id-token: write
 
     steps:
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get current version
         id: version
@@ -45,18 +44,9 @@ jobs:
             echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish
+      - name: Publish & Create Tag
         if: steps.check.outputs.should_publish == 'true'
         uses: ./.github/workflows/reusable-publish.yml
         with:
           version: ${{ steps.version.outputs.current_version }}
           is_manual: true
-
-      - name: Create and push annotated tag (after successful publish)
-        if: steps.check.outputs.should_publish == 'true'
-        run: |
-          VERSION="${{ steps.version.outputs.current_version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release v${VERSION}"
-          git push origin "v${VERSION}"

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -6,11 +6,14 @@ on:
       version:
         required: true
         type: string
+        description: "Monorepo version from package.json (npm dist-tag + annotated git tag)"
       is_manual:
         required: false
         type: boolean
         default: false
+        description: "Whether this was triggered manually (selects the protected release environment)"
 
+# Tag push needs contents:write on the default GITHUB_TOKEN; npm provenance needs id-token:write.
 permissions:
   contents: write
   id-token: write
@@ -18,14 +21,13 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.is_manual && 'release' || '' }}
+    environment: ${{ inputs.is_manual && 'release' || '' }} # Requires approval for manual publishes
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -42,10 +44,12 @@ jobs:
       - name: Build
         run: npx turbo run build
 
-      - name: Determine publish tag
+      - name: Determine dist-tag for publishing
         id: tag
         run: |
           VERSION="${{ inputs.version }}"
+
+          # Prerelease versions (rc, beta, alpha) cannot be published to the npm "latest" dist-tag.
           if [[ "$VERSION" == *"-rc."* ]]; then
             echo "tag=rc"
           elif [[ "$VERSION" == *"-beta."* ]]; then
@@ -60,6 +64,7 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           echo "=== Publishing workspace packages with tag: $TAG ==="
+
           for dir in packages/core packages/utils; do
             if [ -f "$dir/package.json" ]; then
               echo ">>> Publishing: $dir"

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -13,9 +13,10 @@ on:
         default: false
         description: "Whether this was triggered manually (selects the protected release environment)"
 
-# Tag push needs contents:write on the default GITHUB_TOKEN; npm provenance needs id-token:write.
+# Default for jobs that omit `permissions`: checkout + npm publish (no repo writes).
+# Tagging runs in a follow-up job with `contents: write` only (GitHub has no per-step permissions).
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -77,6 +78,18 @@ jobs:
           TAG="${{ steps.tag.outputs.tag }}"
           echo "=== Publishing root package with tag: $TAG ==="
           npx npm@latest publish --tag "$TAG" --provenance --access public
+
+  create-and-push-annotated-tag:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Create and push annotated tag
         run: |

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -6,25 +6,26 @@ on:
       version:
         required: true
         type: string
-        description: "Version being published (used for logging)"
       is_manual:
         required: false
         type: boolean
         default: false
-        description: "Whether this was triggered manually (affects environment protection)"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.is_manual && 'release' || '' }} # Requires approval for manual publishes
+    environment: ${{ inputs.is_manual && 'release' || '' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -41,12 +42,10 @@ jobs:
       - name: Build
         run: npx turbo run build
 
-      - name: Determine dist-tag for publishing
+      - name: Determine publish tag
         id: tag
         run: |
           VERSION="${{ inputs.version }}"
-
-          # Prerelease versions (rc, beta, alpha) cannot be published to 'latest' tag
           if [[ "$VERSION" == *"-rc."* ]]; then
             echo "tag=rc"
           elif [[ "$VERSION" == *"-beta."* ]]; then
@@ -61,7 +60,6 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           echo "=== Publishing workspace packages with tag: $TAG ==="
-
           for dir in packages/core packages/utils; do
             if [ -f "$dir/package.json" ]; then
               echo ">>> Publishing: $dir"
@@ -74,3 +72,11 @@ jobs:
           TAG="${{ steps.tag.outputs.tag }}"
           echo "=== Publishing root package with tag: $TAG ==="
           npx npm@latest publish --tag "$TAG" --provenance --access public
+
+      - name: Create and push annotated tag
+        run: |
+          VERSION="${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adaptate",
-  "version": "2.2.3-beta.0",
+  "version": "2.2.3-beta.1",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adaptate/core",
-  "version": "2.2.3-beta.0",
+  "version": "2.2.3-beta.1",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adaptate/utils",
-  "version": "2.2.3-beta.0",
+  "version": "2.2.3-beta.1",
   "author": {
     "name": "Peramanathan Sathyamoorthy",
     "url": "https://github.com/p10ns11y/adaptate.git"


### PR DESCRIPTION
## Summary

This PR improves the release workflow by moving tag creation logic into the reusable publish workflow.

### Changes

- **`reusable-publish.yml`**: Now handles both publishing **and** creating an annotated tag after a successful publish.
- **`release.yml`**: Simplified. It only checks if the version changed and calls the reusable workflow. No more tag creation logic here.

### Why this is better

- **Publish first, tag later**: Tags are now only created after publishing succeeds (previously we were creating tags optimistically).
- **Better separation**: `release.yml` focuses on decision making, while `reusable-publish.yml` owns the full publish + tag flow.
- Cleaner and more maintainable structure.

### Flow

Check version changed?
↓
Publish packages
↓
Create annotated tag (only on success)

This is the final shape of the release workflow after multiple iterations.

---

### Panicans, DON'T PANIC

This GitHub user is valid GitHub Bot for Actions


```yaml
git config user.name "github-actions[bot]"
git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
git tag -a "v${VERSION}" -m "Release v${VERSION}"
git push origin "v${VERSION}"
```

<img width="2060" height="1334" alt="screenshot-2026-05-15_07-22-09" src="https://github.com/user-attachments/assets/d49c4413-ca51-4d74-87b4-52521c2e1a58" />

### References

https://api.github.com/users/github-actions[bot] (to get the user id of github action bot)

https://docs.github.com/en/search?search-overlay-input=41898282+github-actions+users+noreply+github+com&query=github-actions%5Bbot%5D&search-overlay-open=true&search-overlay-ask-ai=true

https://docs.github.com/en/search?search-overlay-input=github-actions+bot+for+commit+in+GitHub+Actions&query=github-actions%5Bbot%5D&search-overlay-open=true&search-overlay-ask-ai=true
