### PR TITLE
fix(ci): allow contents:write for reusable publish callers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,11 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should_publish == 'true'
 
+    # Ceiling for the called workflow: reusable-publish tags the repo (contents:write).
+    # Nested jobs cannot exceed the caller job's permissions.
     permissions:
-      contents: read
-      id-token: write # Required for OIDC trusted publishing (npm provenance)
+      contents: write
+      id-token: write # OIDC trusted publishing (npm provenance)
 
     uses: ./.github/workflows/reusable-publish.yml
     with:

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -15,6 +15,7 @@ on:
 
 # Default for jobs that omit `permissions`: checkout + npm publish (no repo writes).
 # Tagging runs in a follow-up job with `contents: write` only (GitHub has no per-step permissions).
+# Callers must grant at least contents: write on the job that `uses:` this workflow, or nested jobs cannot request write.
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
GitHub caps nested reusable-workflow jobs by the calling job's token
permissions; grant contents:write on release publish so tag push is valid.
Document the requirement in both workflows.

Co-authored-by: Cursor <cursoragent@cursor.com>
